### PR TITLE
Update Inventek ISM43362 WiFi driver (version 1.14.0)

### DIFF
--- a/ARM.CMSIS-Driver.pdsc
+++ b/ARM.CMSIS-Driver.pdsc
@@ -7,6 +7,10 @@
   <license>LICENSE.txt</license>
 
   <releases>
+    <release version="2.7.2-dev0">
+      Updated Inventek ISM43362 WiFi driver (version 1.14.0):
+      - Added statically allocated control block for asynchronous thread if FreeRTOS is used
+    </release>
     <release version="2.7.1" date="2022-04-26">
       Added support for Arm Cortex-M85 processor based devices
       Added support for Arm China Star-MC1 processor based devices
@@ -449,7 +453,7 @@
     <!-- CMSIS-Driver WiFi -->
 
     <!-- Inventek ISM43362 -->    
-    <component Cvendor="Keil" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="ISM43362" Capiversion="1.1.0" Cvariant="SPI" Cversion="1.13.0" condition="CMSIS Core with RTOS2 and SPI Driver">
+    <component Cvendor="Keil" Cclass="CMSIS Driver" Cgroup="WiFi" Csub="ISM43362" Capiversion="1.1.0" Cvariant="SPI" Cversion="1.14.0" condition="CMSIS Core with RTOS2 and SPI Driver">
       <description>WiFi Inventek ISM43362/ISM43340 Driver (SPI)</description>
       <RTE_Components_h>
         <!-- the following content goes into file 'RTE_Components.h' -->


### PR DESCRIPTION
- add statically allocated control block for asynchronous thread if FreeRTOS is used