### PR TITLE
Update GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,14 +33,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: Open-CMSIS-Pack/gen-pack-action@main
         with:
-          doxygen-version: 1.9.2
+          doxygen-version: 1.9.6
           packchk-version: 1.4.1
           gen-doc-script: ./Documentation/Doxygen/gen_doc.sh
           doc-path: ./Documentation/html

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   pack:
     name: Generate pack
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Documentation/Doxygen/gen_doc.sh
+++ b/Documentation/Doxygen/gen_doc.sh
@@ -6,7 +6,7 @@
 # Pre-requisites:
 # - bash shell (for Windows: install git for Windows)
 # - curl
-# - doxygen 1.9.2
+# - doxygen 1.9.6
 # - linkchecker (can be skipped with -s)
 
 set -o pipefail
@@ -14,11 +14,11 @@ set -o pipefail
 # Set version of gen pack library
 # For available versions see https://github.com/Open-CMSIS-Pack/gen-pack/tags.
 # Use the tag name without the prefix "v", e.g., 0.7.0
-REQUIRED_GEN_PACK_LIB="0.9.1"
+REQUIRED_GEN_PACK_LIB="0.11.1"
 
 DIRNAME=$(dirname "$(readlink -f "$0")")
 GENDIR=../html
-REQ_DXY_VERSION="1.9.2"
+REQ_DXY_VERSION="1.9.6"
 
 RUN_LINKCHECKER=1
 


### PR DESCRIPTION
This PR updates the GitHub Actions runner from ubuntu-20.04 to ubuntu-22.04.