### PR TITLE
Updated Doxygen version to 1.13.2, a.o.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Generate pack
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -14,9 +14,9 @@ concurrency:
 jobs:
   pack:
     name: Generate pack
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
       - uses: Open-CMSIS-Pack/gen-pack-action@main
         with:
           doxygen-version: 1.13.2
-          packchk-version: 1.4.1
+          packchk-version: 1.4.2
           gen-doc-script: ./Documentation/Doxygen/gen_doc.sh
           doc-path: ./Documentation/html
           gen-pack-script: ./gen_pack.sh --no-preprocess

--- a/Documentation/Doxygen/driver.dxy.in
+++ b/Documentation/Doxygen/driver.dxy.in
@@ -991,16 +991,16 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./src/mainpage.md     \
-                         ./src/history.md      \
-                         ./src/history.txt     \
-                         ./src/ethernet.md     \
-                         ./src/usb.md          \
-                         ./src/wifi.md         \
-                         ./src/flash.md        \
-                         ./src/i2c.md          \
-                         ./src/nand.md         \
-                         ./src/spi.md          \
+INPUT                  = ./src/mainpage.md \
+                         ./src/history.md \
+                         ./src/history.txt \
+                         ./src/ethernet.md \
+                         ./src/usb.md \
+                         ./src/wifi.md \
+                         ./src/flash.md \
+                         ./src/i2c.md \
+                         ./src/nand.md \
+                         ./src/spi.md \
                          ./src/shield_layer.md
 
 # This tag can be used to specify the character encoding of the source files

--- a/Documentation/Doxygen/gen_doc.sh
+++ b/Documentation/Doxygen/gen_doc.sh
@@ -6,7 +6,7 @@
 # Pre-requisites:
 # - bash shell (for Windows: install git for Windows)
 # - curl
-# - doxygen 1.9.6
+# - doxygen 1.13.2
 # - linkchecker (can be skipped with -s)
 
 set -o pipefail
@@ -14,7 +14,7 @@ set -o pipefail
 # Set version of gen pack library
 # For available versions see https://github.com/Open-CMSIS-Pack/gen-pack/tags.
 # Use the tag name without the prefix "v", e.g., 0.7.0
-REQUIRED_GEN_PACK_LIB="0.11.2"
+REQUIRED_GEN_PACK_LIB="0.11.3"
 
 DIRNAME=$(dirname "$(readlink -f "$0")")
 GENDIR=../html

--- a/Documentation/Doxygen/style_template/extra_stylesheet.css
+++ b/Documentation/Doxygen/style_template/extra_stylesheet.css
@@ -70,7 +70,7 @@
 	  
 	  --icon-background-color: #728DC1;
 	  --icon-foreground-color: white;
-	  --icon-doc-image: url('doc.svg');
+	  --icon-doc-image: url('docd.svg');
 	  
 	  /* brief member declaration list */
 	  --memdecl-background-color:#F9FAFC;

--- a/gen_pack.sh
+++ b/gen_pack.sh
@@ -9,7 +9,7 @@ set -o pipefail
 # Set version of gen pack library
 # For available versions see https://github.com/Open-CMSIS-Pack/gen-pack/tags.
 # Use the tag name without the prefix "v", e.g., 0.7.0
-REQUIRED_GEN_PACK_LIB="0.9.0"
+REQUIRED_GEN_PACK_LIB="0.11.3"
 
 # Set default command line arguments
 DEFAULT_ARGS=(-c "")


### PR DESCRIPTION
Updated 
- Doxygen to version 1.13.2
- gen_pack_lib to version 0.11.3
- packchk to version 1.4.2
- ubuntu-24.04
- actions/checkout@v4.2.2
- the  *.dxy.in file