### PR TITLE
fix(WiFi/ESP32): check cb_event for NULL before calling on station connect/disconnect

### DIFF
--- a/WiFi/ESP32/WiFi_ESP32.c
+++ b/WiFi/ESP32/WiFi_ESP32.c
@@ -376,13 +376,17 @@ void AT_Notify (uint32_t event, void *arg) {
     /* Station connects to the local AP */
     ex = AT_Resp_StaMac (mac);
 
-    pCtrl->cb_event (ARM_WIFI_EVENT_AP_CONNECT, mac);
+    if (pCtrl->cb_event != NULL) {
+      pCtrl->cb_event (ARM_WIFI_EVENT_AP_CONNECT, mac);
+    }
   }
   else if (event == AT_NOTIFY_STATION_DISCONNECTED) {
     /* Station disconnects from the local AP */
     ex = AT_Resp_StaMac (mac);
 
-    pCtrl->cb_event (ARM_WIFI_EVENT_AP_DISCONNECT, mac);
+    if (pCtrl->cb_event != NULL) {
+      pCtrl->cb_event (ARM_WIFI_EVENT_AP_DISCONNECT, mac);
+    }
   }
   else if (event == AT_NOTIFY_CONNECTED) {
     /* Local station connected to an AP */


### PR DESCRIPTION
Fixes #13.

`ARM_WIFI_Initialize()` accepts a `cb_event` callback that, per the driver's documented behavior, may be `NULL` if the caller doesn't need event callbacks. `pCtrl->cb_event` is also explicitly set to `NULL` on `Uninitialize()`.

However `AT_Notify()` calls `pCtrl->cb_event(...)` unconditionally for `AT_NOTIFY_STATION_CONNECTED` and `AT_NOTIFY_STATION_DISCONNECTED` (which raise `ARM_WIFI_EVENT_AP_CONNECT`/`ARM_WIFI_EVENT_AP_DISCONNECT` respectively) - the only two call sites of `cb_event` in this function - with no NULL check. As the issue describes, this triggers whenever a station connects to or disconnects from the local AP (e.g. a remote host dropping its connection) while no event callback was registered, resulting in a null pointer call.

Fix: guard both call sites with `if (pCtrl->cb_event != NULL)`, exactly as suggested in the issue and confirmed by @VladimirUmek's comment ("this check shall be added").

### Test plan

No physical ESP32 hardware/AT-command host available to exercise this path end-to-end. Verified by code inspection: confirmed these are the only two `cb_event` invocations inside `AT_Notify()`, confirmed `cb_event` can legitimately be `NULL` per `ARM_WIFI_Initialize()`'s documented parameter contract and its `Uninitialize()` reset, and confirmed no other AT_NOTIFY_* branch in the same function calls `cb_event` (so no other call sites need the same guard).

### Disclosure

Generative AI (Claude) was used to help investigate this and implement the fix. All changes were reviewed by me before submission.
